### PR TITLE
Visualize the problem with @DirtiesContext

### DIFF
--- a/src/main/java/me/spike/beanreplacement/consumer/Consumer.java
+++ b/src/main/java/me/spike/beanreplacement/consumer/Consumer.java
@@ -3,6 +3,7 @@ package me.spike.beanreplacement.consumer;
 import lombok.AllArgsConstructor;
 import me.spike.beanreplacement.service.EnergeticGreeter;
 import me.spike.beanreplacement.service.MessageRepository;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jms.annotation.JmsListener;
 import org.springframework.jms.support.JmsHeaders;
 import org.springframework.messaging.handler.annotation.Header;
@@ -15,11 +16,15 @@ import javax.jms.TextMessage;
 public class Consumer {
     private EnergeticGreeter greeter;
     private MessageRepository repository;
+    private ApplicationContext applicationContext;
 
     @JmsListener(destination = "foo.bar")
     public void consume(
             @Header(name = JmsHeaders.MESSAGE_ID, required = false) String messageId,
             TextMessage textMessage) {
+
+        System.out.println("--- Consumed by context: " + applicationContext.toString());
+
         if ("Ahem hello!!".equals(greeter.welcome().getContent())) {
             repository.save();
         }

--- a/src/main/java/me/spike/beanreplacement/consumer/Consumer.java
+++ b/src/main/java/me/spike/beanreplacement/consumer/Consumer.java
@@ -18,7 +18,7 @@ public class Consumer {
     private MessageRepository repository;
     private ApplicationContext applicationContext;
 
-    @JmsListener(destination = "foo.bar")
+    @JmsListener(destination = "${consumer.destination}")
     public void consume(
             @Header(name = JmsHeaders.MESSAGE_ID, required = false) String messageId,
             TextMessage textMessage) {

--- a/src/test/java/me/spike/beanreplacement/DestinationValueInitializer.java
+++ b/src/test/java/me/spike/beanreplacement/DestinationValueInitializer.java
@@ -1,0 +1,16 @@
+package me.spike.beanreplacement;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.UUID;
+
+public class DestinationValueInitializer implements
+        ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        TestPropertyValues.of("consumer.destination=" + UUID.randomUUID().toString()).applyTo(applicationContext);
+    }
+}

--- a/src/test/java/me/spike/beanreplacement/FirstRestApplicationTest.java
+++ b/src/test/java/me/spike/beanreplacement/FirstRestApplicationTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -15,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ContextConfiguration(initializers = DestinationValueInitializer.class)
 //@DirtiesContext // TODO - Uncomment for all tests in this project to pass when entire suite is run
 public class FirstRestApplicationTest {
 

--- a/src/test/java/me/spike/beanreplacement/JMSConsumerIntegrationTest.java
+++ b/src/test/java/me/spike/beanreplacement/JMSConsumerIntegrationTest.java
@@ -6,10 +6,12 @@ import me.spike.beanreplacement.service.MessageRepository;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.util.concurrent.TimeUnit;
 
@@ -18,10 +20,14 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(initializers = DestinationValueInitializer.class)
 public class JMSConsumerIntegrationTest {
 
     @Autowired
     private JmsTemplate jmsTemplate;
+
+    @Value("${consumer.destination}")
+    private String destination;
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -39,7 +45,7 @@ public class JMSConsumerIntegrationTest {
 
         System.out.println("--- Send from context: " + applicationContext.toString());
 
-        jmsTemplate.send("foo.bar", session -> session.createTextMessage("hello world"));
+        jmsTemplate.send(destination, session -> session.createTextMessage("hello world"));
 
         Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(
                 () -> verify(repository, times(1)).save()

--- a/src/test/java/me/spike/beanreplacement/JMSConsumerIntegrationTest.java
+++ b/src/test/java/me/spike/beanreplacement/JMSConsumerIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.jms.core.JmsTemplate;
 
 import java.util.concurrent.TimeUnit;
@@ -22,6 +23,9 @@ public class JMSConsumerIntegrationTest {
     @Autowired
     private JmsTemplate jmsTemplate;
 
+    @Autowired
+    private ApplicationContext applicationContext;
+
     @MockBean
     private EnergeticGreeter greeter;
 
@@ -32,6 +36,8 @@ public class JMSConsumerIntegrationTest {
     @Test
     public void shouldInvokeRepositoryWhenGreetedWithASpecificMessage() {
         when(greeter.welcome()).thenReturn(new Message("Ahem hello!!"));
+
+        System.out.println("--- Send from context: " + applicationContext.toString());
 
         jmsTemplate.send("foo.bar", session -> session.createTextMessage("hello world"));
 

--- a/src/test/java/me/spike/beanreplacement/RestApplicationTest.java
+++ b/src/test/java/me/spike/beanreplacement/RestApplicationTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ContextConfiguration(initializers = DestinationValueInitializer.class)
 //@DirtiesContext // TODO - Uncomment for all tests in this project to pass when entire suite is run
 public class RestApplicationTest {
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 spring.activemq.in-memory=true
 spring.activemq.broker-url=vm://embedded?broker.persistent=false,useShutdownHook=false
 
+consumer.destination=foo.bar


### PR DESCRIPTION
Referring to the question on [StackOverflow](https://stackoverflow.com/questions/62489682/why-dirtiescontext-is-needed-on-other-test-classes-to-mock-bean-dependency-for-c/62508609#62508609)

if you now run `./gradlew test -i --rerun-tasks` without the use of `@DirtiesContext` you should see the following:

```
JMSConsumerIntegrationTest > shouldInvokeRepositoryWhenGreetedWithASpecificMessage() STANDARD_OUT
    --- Send from context: org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@3b776a76, started on Mon Jun 22 08:33:50 CEST 2020
    --- Consumed by context: org.springframework.web.context.support.GenericWebApplicationContext@235dfc4d, started on Mon Jun 22 08:33:48 CEST 2020
```

with using `@DirtiesContext` and therefore shutting down application contexts from the previous tests:

```
JMSConsumerIntegrationTest > shouldInvokeRepositoryWhenGreetedWithASpecificMessage() STANDARD_OUT
    Sending message in context: org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@35828e64, started on Mon Jun 22 08:21:17 CEST 2020
    consumed!
    org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext@35828e64, started on Mon Jun 22 08:21:17 CEST 2020
```

With the second commit, you are now able to run all tests together without the need for `@DirtiesContext`.